### PR TITLE
Add support for omniauth configuration

### DIFF
--- a/gitlab.tf
+++ b/gitlab.tf
@@ -51,6 +51,23 @@ resource "kubernetes_secret" "gitlab_gcs_credentials" {
   }
 }
 
+resource "kubernetes_secret" "google_omniauth_provider" {
+  metadata {
+    name = "gitlab-google-oauth2"
+  }
+
+  data = {
+    provider = <<EOT
+name: google_oauth2
+app_id: "${var.omniauth_google_client_id}"
+app_secret: "${var.omniauth_google_client_secret}"
+args:
+  access_type: offline
+  approval_prompt: ''
+EOT
+  }
+}
+
 data "helm_repository" "gitlab" {
   name = "gitlab"
   url  = "https://charts.gitlab.io"
@@ -60,14 +77,18 @@ data "template_file" "helm_values" {
   template = "${file("${path.module}/values.yaml.tpl")}"
 
   vars = {
-    DOMAIN                = "${var.domain != "" ? var.domain : "gitlab.${google_compute_address.gitlab.address}.xip.io"}"
-    INGRESS_IP            = "${google_compute_address.gitlab.address}"
-    DB_PRIVATE_IP         = "${google_sql_database_instance.gitlab_db.private_ip_address}"
-    REDIS_PRIVATE_IP      = "${google_redis_instance.gitlab.host}"
-    PROJECT_ID            = "${var.project_id}"
-    CERT_MANAGER_EMAIL    = "${var.certmanager_email}"
-    GITLAB_RUNNER_INSTALL = "${var.gitlab_runner_install ? "true" : "false"}"
-    GITLAB_EDITION        = "${var.gitlab_edition}"
+    DOMAIN                           = "${var.domain != "" ? var.domain : "gitlab.${google_compute_address.gitlab.address}.xip.io"}"
+    INGRESS_IP                       = "${google_compute_address.gitlab.address}"
+    DB_PRIVATE_IP                    = "${google_sql_database_instance.gitlab_db.private_ip_address}"
+    REDIS_PRIVATE_IP                 = "${google_redis_instance.gitlab.host}"
+    PROJECT_ID                       = "${var.project_id}"
+    CERT_MANAGER_EMAIL               = "${var.certmanager_email}"
+    GITLAB_RUNNER_INSTALL            = "${var.gitlab_runner_install ? "true" : "false"}"
+    GITLAB_EDITION                   = "${var.gitlab_edition}"
+    OMNIAUTH_ENABLED                 = "${var.omniauth_enabled}"
+    OMNIAUTH_SSO_PROVIDERS           = "${jsonencode(var.omniauth_sso_providers)}"
+    OMNIAUTH_SYNC_PROFILE_PROVIDERS  = "${jsonencode(var.omniauth_sync_profile_providers)}"
+    OMNIAUTH_SYNC_PROFILE_ATTRIBUTES = "${jsonencode(var.omniauth_sync_profile_attributes)}"
   }
 }
 

--- a/gitlab.tf
+++ b/gitlab.tf
@@ -59,8 +59,8 @@ resource "kubernetes_secret" "google_omniauth_provider" {
   data = {
     provider = <<EOT
 name: google_oauth2
-app_id: "${var.omniauth_google_client_id}"
-app_secret: "${var.omniauth_google_client_secret}"
+app_id: "${var.omniauth.google_client_id}"
+app_secret: "${var.omniauth.google_client_secret}"
 args:
   access_type: offline
   approval_prompt: ''
@@ -85,10 +85,10 @@ data "template_file" "helm_values" {
     CERT_MANAGER_EMAIL               = "${var.certmanager_email}"
     GITLAB_RUNNER_INSTALL            = "${var.gitlab_runner_install ? "true" : "false"}"
     GITLAB_EDITION                   = "${var.gitlab_edition}"
-    OMNIAUTH_ENABLED                 = "${var.omniauth_enabled}"
-    OMNIAUTH_SSO_PROVIDERS           = "${jsonencode(var.omniauth_sso_providers)}"
-    OMNIAUTH_SYNC_PROFILE_PROVIDERS  = "${jsonencode(var.omniauth_sync_profile_providers)}"
-    OMNIAUTH_SYNC_PROFILE_ATTRIBUTES = "${jsonencode(var.omniauth_sync_profile_attributes)}"
+    OMNIAUTH_ENABLED                 = var.omniauth.enabled
+    OMNIAUTH_SSO_PROVIDERS           = jsonencode(var.omniauth.sso_providers)
+    OMNIAUTH_SYNC_PROFILE_PROVIDERS  = jsonencode(var.omniauth.sync_profile_providers)
+    OMNIAUTH_SYNC_PROFILE_ATTRIBUTES = jsonencode(var.omniauth.sync_profile_attributes)
   }
 }
 

--- a/values.yaml.tpl
+++ b/values.yaml.tpl
@@ -73,6 +73,21 @@ global:
         secret: gitlab-rails-storage
         key: connection
 
+    omniauth:
+      enabled: ${OMNIAUTH_ENABLED}
+      allowSingleSignOn: ${OMNIAUTH_SSO_PROVIDERS}
+      autoLinkLdapUser: false
+      autoLinkSamlUser: false
+      blockAutoCreatedUsers: false
+      externalProviders: []
+      syncProfileFromProvider: ${OMNIAUTH_SYNC_PROFILE_PROVIDERS}
+      syncProfileAttributes: ${OMNIAUTH_SYNC_PROFILE_ATTRIBUTES}
+      allowBypassTwoFactor: []
+      autoSignInWithProvider:
+      providers:
+        - secret: gitlab-google-oauth2
+          key: provider
+
 certmanager-issuer:
   email: ${CERT_MANAGER_EMAIL}
 

--- a/variables.tf
+++ b/variables.tf
@@ -68,7 +68,7 @@ variable "gke_min_version" {
 }
 
 variable "gke_enable_abac" {
-  default = false
+  default     = false
   description = "Insecure! Flag if deprecated ABAC authorization should be enabled."
 }
 
@@ -97,35 +97,33 @@ variable "network_cidr" {
   description = "Kubernetes network CIDR"
 }
 
-variable "omniauth_enabled" {
-  default     = false
-  description = "Should the omniauth configuration be enabled or not"
-}
+variable "omniauth" {
+  description = <<EOF
 
-variable "omniauth_sso_providers" {
-  type        = list(string)
-  default     = []
-  description = "A list of single sign on providers to enable"
-}
+  enabled: Should the omniauth configuration be enabled in Gitlab or not.
+  sso_providers: A list of single sign on providers to enable.
+  sso_profile_providers: List of provider names that GitLab should automatically sync profile information from.
+  sso_profile_attributes: List of profile attributes to sync from the provider upon login.
+  google_client_id: The client ID to use for Google OAuth2.
+  google_client_secret: The client secret to use for Google OAuth2.
 
-variable "omniauth_sync_profile_providers" {
-  type        = list(string)
-  default     = []
-  description = "List of provider names that GitLab should automatically sync profile information from."
-}
+  EOF
 
-variable "omniauth_sync_profile_attributes" {
-  type        = list(string)
-  default     = ["email"]
-  description = "List of profile attributes to sync from the provider upon login."
-}
+  type = object({
+    enabled                 = bool
+    sso_providers           = list(string)
+    sync_profile_providers  = list(string)
+    sync_profile_attributes = list(string)
+    google_client_id        = string
+    google_client_secret    = string
+  })
 
-variable "omniauth_google_client_id" {
-  default     = ""
-  description = "The client ID to use for Google OAuth2"
-}
-
-variable "omniauth_google_client_secret" {
-  default     = ""
-  description = "The client secret to use for Google OAuth2"
+  default = {
+    enabled                 = false
+    sso_providers           = []
+    sync_profile_providers  = []
+    sync_profile_attributes = ["email"]
+    google_client_id        = ""
+    google_client_secret    = ""
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -96,3 +96,36 @@ variable "network_cidr" {
   default     = "10.0.0.0/16"
   description = "Kubernetes network CIDR"
 }
+
+variable "omniauth_enabled" {
+  default     = false
+  description = "Should the omniauth configuration be enabled or not"
+}
+
+variable "omniauth_sso_providers" {
+  type        = list(string)
+  default     = []
+  description = "A list of single sign on providers to enable"
+}
+
+variable "omniauth_sync_profile_providers" {
+  type        = list(string)
+  default     = []
+  description = "List of provider names that GitLab should automatically sync profile information from."
+}
+
+variable "omniauth_sync_profile_attributes" {
+  type        = list(string)
+  default     = ["email"]
+  description = "List of profile attributes to sync from the provider upon login."
+}
+
+variable "omniauth_google_client_id" {
+  default     = ""
+  description = "The client ID to use for Google OAuth2"
+}
+
+variable "omniauth_google_client_secret" {
+  default     = ""
+  description = "The client secret to use for Google OAuth2"
+}


### PR DESCRIPTION
The omniauth.providers was left hardcoded along
with google kubernetes secret non-conditional creation.
This is due to it being complex to make both configurations
work and 'enabled' together with available conditional
statements.